### PR TITLE
[Feat] Add Kpatch support

### DIFF
--- a/base/install.sh
+++ b/base/install.sh
@@ -146,6 +146,10 @@ on_install() {
       ui_print "- Installing from KernelSU app"
       ui_print "- KernelSU version: $KSU_KERNEL_VER_CODE (kernel) + $KSU_VER_CODE (ksud)"
       UNZIP="/data/adb/ksu/bin/busybox unzip"
+  elif [ "$BOOTMODE" ] && [ "$APATCH" ]; then
+      ui_print "- Installing from APatch app"
+      ui_print "- APatch version: $APATCH_VER_CODE. Magisk version: $MAGISK_VER_CODE"
+      UNZIP="/data/adb/ap/bin/busybox unzip"
   elif [ "$BOOTMODE" ] && [ "$MAGISK_VER_CODE" ]; then
       ui_print "- Installing from Magisk app"
       ui_print "- Magisk version: $MAGISK_VER_CODE"


### PR DESCRIPTION
Adding APatch support.

Just adjusted the busybox path and added a new case to the switchcase
```
panther:/sdcard/Download $ cat APatch_install_log_2024-07-02-17-33-29.log
    _    ____       _       _
   / \  |  _ \ __ _| |_ ___| |__
  / _ \ | |_) / _` | __/ __| '_ \
 / ___ \|  __/ (_| | || (__| | | |
/_/   \_\_|   \__,_|\__\___|_| |_|

- Preparing image
- Module size: 253.51 MB
e2fsck 1.46.6 (1-Feb-2023)
- Estimated minimum size of the filesystem: 75214
e2fsck 1.46.6 (1-Feb-2023)
- Target image size: 598.97 MB
resize2fs 1.46.6 (1-Feb-2023)
The filesystem is already 585953 (1k) blocks long.  Nothing to do!

e2fsck 1.46.6 (1-Feb-2023)
- Mounting image
Source path is not read-only
- Current boot slot: _a
- Device is system-as-root
Archive:  /data/user/0/me.bmax.apatch/cache/module.zip
  inflating: module.prop
Archive:  /data/user/0/me.bmax.apatch/cache/module.zip
  inflating: module.prop
  inflating: install.sh
  inflating: post-fs-data.sh
  inflating: system.prop
  inflating: service.sh

    ********************************************
    *          Magisk-/KernelSU-Frida          *
    ********************************************

- Detected architecture: arm64
- Installing from APatch app
- APatch version: 10763. Magisk version: 27000
- Extracting module files
- Setting permissions
- Done
```